### PR TITLE
use github provided repo for maven url

### DIFF
--- a/Armadillo/build.gradle
+++ b/Armadillo/build.gradle
@@ -100,7 +100,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/scribd/armadillo")
+            url = uri("https://maven.pkg.github.com/$githubRepo")
             credentials {
                 username = "$githubUsername"
                 password = "$githubPassword"

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     ext.githubUsername = "$System.env.GITHUB_USERNAME"
     ext.githubPassword = "$System.env.GITHUB_PASSWORD"
+    ext.githubRepo = "$System.env.GITHUB_REPOSITORY"
 
     ext.kotlin_version = '1.6.0'
 


### PR DESCRIPTION
Prevents this error when forks attempt a release:

<img width="1265" alt="Screen Shot 2022-07-20 at 1 32 37 PM" src="https://user-images.githubusercontent.com/662419/180067525-bce82ae6-d4b0-41a4-8a7a-b900f658ff71.png">
