### PR TITLE
[APT-7162] Fixed maven publishing issue

### DIFF
--- a/Armadillo/build.gradle
+++ b/Armadillo/build.gradle
@@ -88,7 +88,7 @@ publishing {
                 groupId project.PACKAGE_NAME
                 version project.LIBRARY_VERSION
                 artifactId project.getName().toLowerCase()
-                from components.findByName("android${variant.name.capitalize()}")
+                from components.findByName(variant.name.capitalize())
                 // Add sources to artifact
                 artifact androidSourcesJar
                 // Add javadocs

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,5 @@
 # Project Armadillo Release Notes
 
-## 1.0.5-SNAPSHOT
-
 ## 1.0.4
 - Upgraded Exoplayer version to 2.17.1
 - Upgraded Java version to 11

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,13 +12,13 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 PACKAGE_NAME=com.scribd.armadillo
-LIBRARY_VERSION=1.0.5-SNAPSHOT
+LIBRARY_VERSION=1.0.4
 EXOPLAYER_VERSION=2.17.1
 RXJAVA_VERSION=2.2.4
 RXANDROID_VERSION=2.0.1
 DAGGER_VERSION=2.16
 MAVEN_PUBLISH_VERSION=3.6.2
-DOKKA_VERSION=1.4.20
+DOKKA_VERSION=1.6.10
 # Update package-list when updating build tools version
 BUILD_TOOLS_VERSION=29.0.3
 android.useAndroidX=true


### PR DESCRIPTION
Upgrading to Android 12 required an update to our gradle version which broke our Armadillo publishing process

Revert the "post-release" because apparently we don't have to anymore? and to recreate the publish tag for 1.0.4