### PR TITLE
[APT-7170] Fixed github publishing in gradle 

### DIFF
--- a/Armadillo/build.gradle
+++ b/Armadillo/build.gradle
@@ -85,10 +85,10 @@ publishing {
     publications {
         android.libraryVariants.all { variant ->
             "${variant.name.capitalize()}Aar"(MavenPublication) {
+                from(components[variant.name])
                 groupId project.PACKAGE_NAME
                 version project.LIBRARY_VERSION
                 artifactId project.getName().toLowerCase()
-                from components.findByName(variant.name.capitalize())
                 // Add sources to artifact
                 artifact androidSourcesJar
                 // Add javadocs


### PR DESCRIPTION
We were finally able to get successful publishes, but the published package was missing the .AAR and .module files needed to import armadillo into projects.

Tested in a forked repo and was able to import 1.0.4 successfully