### PR TITLE
[APT-7199] 1.0.5 - Fixed Issue with Headers not applied to Requests

### DIFF
--- a/Armadillo/src/main/java/com/scribd/armadillo/download/DownloadEngine.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/download/DownloadEngine.kt
@@ -85,7 +85,7 @@ internal class ExoplayerDownloadEngine @Inject constructor(private val context: 
             .build()
         return when (@C.ContentType val type = Util.inferContentType(uri)) {
             C.TYPE_HLS ->
-                DownloadHelper.forMediaItem(context, mediaItem, renderersFactory, DefaultDataSource.Factory(context, DefaultHttpDataSource.Factory()))
+                DownloadHelper.forMediaItem(context, mediaItem, renderersFactory, DefaultDataSource.Factory(context, dataSourceFactory))
             C.TYPE_OTHER -> DownloadHelper.forMediaItem(context, mediaItem)
             else -> throw IllegalStateException("Unsupported type: $type")
         }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Project Armadillo Release Notes
 
+## 1.0.5
+- Fixed issue with headers not properly being applied to Api Requests
+
 ## 1.0.4
 - Upgraded Exoplayer version to 2.17.1
 - Upgraded Java version to 11

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 PACKAGE_NAME=com.scribd.armadillo
-LIBRARY_VERSION=1.0.4
+LIBRARY_VERSION=1.0.5
 EXOPLAYER_VERSION=2.17.1
 RXJAVA_VERSION=2.2.4
 RXANDROID_VERSION=2.0.1


### PR DESCRIPTION
In the Android 12 rework for 1.0.4, I accidentally created a new instance of the `DefaultHttpDataSource` rather than using the one that had the request headers applied