### PR TITLE
[APT-7522] Fix lost playback from stopped foreground services

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Project Armadillo Release Notes
 
+## 1.0.6
+- Fixed issue with ArmadilloState events not being emitted on Android 12+
+
 ## 1.0.5
 - Fixed issue with headers not properly being applied to Api Requests
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 PACKAGE_NAME=com.scribd.armadillo
-LIBRARY_VERSION=1.0.5
+LIBRARY_VERSION=1.0.6
 EXOPLAYER_VERSION=2.17.1
 RXJAVA_VERSION=2.2.4
 RXANDROID_VERSION=2.0.1


### PR DESCRIPTION
As of Android 12, Foreground services cannot be started while the app is in the background. Historically, we had a mechanism that would continuously launch the service (which simply sustained the existing one if there was an existing instance running), so in the case of the service being stopped by the OS or a bug in the playback system, it would carry on as normal.

Now, if the service is stopped while the app is in the background, it cannot be restored automatically, causing the app to no longer intermittently emit playback duration progress updates. However, the exoplayer instance continues to play audio and track the progress independent of the service, so this PR aims to emit progress directly from the the exoplayer instance itself.

It also keeps track of any previous exoplayer instances and clears them, as a stopped `PlaybackService` will not properly `deinit()` the existing exoplayer instance at hand.