### PR TITLE
[APT-7521] Added Error Support for ForegroundServiceStartNotAllowedException

### DIFF
--- a/Armadillo/src/main/java/com/scribd/armadillo/analytics/PlaybackActionTransmitter.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/analytics/PlaybackActionTransmitter.kt
@@ -61,8 +61,10 @@ internal class PlaybackActionTransmitterImpl(private val stateProvider: StateSto
                 } catch (e: Throwable) {
                     // Don't throw exception if user SDK >= android 12 and it's ForegroundServiceStartNotAllowedException
                     // Exceptions kill emissions, but the player still works even after ForegroundServiceStartNotAllowedException
-                        if (hasSnowCone() && e !is ForegroundServiceStartNotAllowedException) {
+                    if (hasSnowCone()) {
+                        if (e !is ForegroundServiceStartNotAllowedException) {
                             throw e
+                        }
                     } else {
                         throw e
                     }

--- a/Armadillo/src/main/java/com/scribd/armadillo/analytics/PlaybackActionTransmitter.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/analytics/PlaybackActionTransmitter.kt
@@ -8,6 +8,7 @@ import com.scribd.armadillo.Milliseconds
 import com.scribd.armadillo.StateStore
 import com.scribd.armadillo.di.Injector
 import com.scribd.armadillo.error.ActionListenerException
+import com.scribd.armadillo.hasSnowCone
 import com.scribd.armadillo.models.ArmadilloState
 import com.scribd.armadillo.models.AudioPlayable
 import com.scribd.armadillo.models.InternalState
@@ -60,10 +61,8 @@ internal class PlaybackActionTransmitterImpl(private val stateProvider: StateSto
                 } catch (e: Throwable) {
                     // Don't throw exception if user SDK >= android 12 and it's ForegroundServiceStartNotAllowedException
                     // Exceptions kill emissions, but the player still works even after ForegroundServiceStartNotAllowedException
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                        if (e !is ForegroundServiceStartNotAllowedException) {
+                        if (hasSnowCone() && e !is ForegroundServiceStartNotAllowedException) {
                             throw e
-                        }
                     } else {
                         throw e
                     }

--- a/Armadillo/src/main/java/com/scribd/armadillo/error/ArmadilloException.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/error/ArmadilloException.kt
@@ -80,6 +80,16 @@ object UnableToLoadDownloadInfo : ArmadilloException(Exception()) {
 }
 
 /**
+ * Occurs when a device supporting Android 12 (SDK 31+) attempts to launch the ExoPlayer DownloadService while the user has put the app
+ * into the background, often during low connectivity when the DownloadHelper.prepare() stalls long enough for the user to put the app in
+ * the background before DownloadService.sendAddDownload
+ */
+
+data class DownloadServiceLaunchedInBackground(val id: Int) : ArmadilloException(Exception()) {
+    override val errorCode = 304
+}
+
+/**
  * Misc Errors
  */
 data class UnexpectedException(val exception: Exception) : ArmadilloException(exception) {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Project Armadillo Release Notes
 
+## 1.0.7
+- Added error state support for ForegroundServiceStartNotAllowedException
+
 ## 1.0.6
 - Fixed issue with ArmadilloState events not being emitted on Android 12+
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 PACKAGE_NAME=com.scribd.armadillo
-LIBRARY_VERSION=1.0.6
+LIBRARY_VERSION=1.0.7
 EXOPLAYER_VERSION=2.17.1
 RXJAVA_VERSION=2.2.4
 RXANDROID_VERSION=2.0.1


### PR DESCRIPTION
ForegroundServiceStartNotAllowedException will no longer cause a crash, and will also report the error to the state observable