### PR TITLE
[APT-7674] Moved download removal from DownloadService to DownloadManager

### DIFF
--- a/Armadillo/src/main/java/com/scribd/armadillo/download/DownloadEngine.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/download/DownloadEngine.kt
@@ -70,8 +70,7 @@ internal class ExoplayerDownloadEngine @Inject constructor(private val context: 
         })
     }
 
-    override fun removeDownload(audiobook: AudioPlayable) =
-        DownloadService.sendRemoveDownload(context, downloadService, audiobook.request.url, true)
+    override fun removeDownload(audiobook: AudioPlayable) = downloadManager.removeDownload(audiobook.request.url)
 
     override fun removeAllDownloads() = downloadManager.removeAllDownloads()
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Project Armadillo Release Notes
 
+## 1.0.8
+- Download removal is now handled by DownloadManager rather than DownloadService
+
+## 1.0.7
+- Added error state support for ForegroundServiceStartNotAllowedException
+
 ## 1.0.7
 - Added error state support for ForegroundServiceStartNotAllowedException
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,9 +6,6 @@
 ## 1.0.7
 - Added error state support for ForegroundServiceStartNotAllowedException
 
-## 1.0.7
-- Added error state support for ForegroundServiceStartNotAllowedException
-
 ## 1.0.6
 - Fixed issue with ArmadilloState events not being emitted on Android 12+
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 PACKAGE_NAME=com.scribd.armadillo
-LIBRARY_VERSION=1.0.7
+LIBRARY_VERSION=1.0.8
 EXOPLAYER_VERSION=2.17.1
 RXJAVA_VERSION=2.2.4
 RXANDROID_VERSION=2.0.1


### PR DESCRIPTION
Currently, we remove audio downloads by launching a service, which can crash the app if that occurs while the app is in the background (typically library sync)

However, `DownloadService.sendRemoveDownload()` ultimately and simply calls `DownloadManager.removeDownload()` so we can swap them out to fix this issue

In my own testing, behavior and cache worked the same for downloaded and downloading files