### PR TITLE
Add support for updating headers during playback

### DIFF
--- a/Armadillo/build.gradle
+++ b/Armadillo/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:${DAGGER_VERSION}"
     implementation 'androidx.media:media:1.6.0'
     testImplementation "org.robolectric:robolectric:4.5.1"
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation("org.assertj:assertj-core:3.10.0")
     testImplementation "org.mockito:mockito-core:2.28.2"
     testImplementation("org.mockito.kotlin:mockito-kotlin:3.2.0") {

--- a/Armadillo/src/main/java/com/scribd/armadillo/Constants.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/Constants.kt
@@ -56,12 +56,14 @@ object Constants {
         const val SET_PLAYBACK_SPEED = "set_playback_speed_action"
         const val UPDATE_PROGRESS = "updated_progress_action"
         const val UPDATE_METADATA = "update_metadata"
+        const val UPDATE_MEDIA_REQUEST = "update_media_request"
 
         object Extras {
             const val IS_IN_FOREGROUND = "is_in_foreground"
             const val PLAYBACK_SPEED = "playback_speed"
             const val METADATA_TITLE = "metadata_title"
             const val METADATA_CHAPTERS = "metadata_chapters"
+            const val MEDIA_REQUEST = "media_request"
         }
     }
 }

--- a/Armadillo/src/main/java/com/scribd/armadillo/actions/Action.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/actions/Action.kt
@@ -95,6 +95,10 @@ internal data class MetadataUpdateAction(val title: String, val chapters: List<C
     override val name: String = "MetadataUpdateAction: $title"
 }
 
+internal data class MediaRequestUpdateAction(val mediaRequest: AudioPlayable.MediaRequest): Action {
+    override val name: String = "MediaRequestUpdateAction: $mediaRequest"
+}
+
 internal object ContentEndedAction : Action {
     override val name = "ContentEndedAction"
 }

--- a/Armadillo/src/main/java/com/scribd/armadillo/di/PlaybackModule.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/di/PlaybackModule.kt
@@ -15,6 +15,8 @@ import com.scribd.armadillo.playback.MediaMetadataCompatBuilderImpl
 import com.scribd.armadillo.playback.PlaybackEngineFactoryHolder
 import com.scribd.armadillo.playback.PlaybackStateBuilderImpl
 import com.scribd.armadillo.playback.PlaybackStateCompatBuilder
+import com.scribd.armadillo.playback.mediasource.MediaSourceRetriever
+import com.scribd.armadillo.playback.mediasource.MediaSourceRetrieverImpl
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -50,4 +52,8 @@ internal class PlaybackModule {
     @Provides
     @Singleton
     fun mediaBrowser(contentSharer: MediaContentSharer): ArmadilloMediaBrowse.Browser = contentSharer
+
+    @Provides
+    @Singleton
+    fun mediaSourceRetriever(mediaSourceRetrieverImpl: MediaSourceRetrieverImpl): MediaSourceRetriever = mediaSourceRetrieverImpl
 }

--- a/Armadillo/src/main/java/com/scribd/armadillo/error/ArmadilloException.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/error/ArmadilloException.kt
@@ -37,6 +37,10 @@ object InvalidPlaybackState : ArmadilloException(Exception()) {
     override val errorCode = 106
 }
 
+data class InvalidRequest(val reason: String) : ArmadilloException(exception = Exception(reason)) {
+    override val errorCode: Int = 107
+}
+
 /**
  * Playback Errors
  */

--- a/Armadillo/src/main/java/com/scribd/armadillo/extensions/TransportControlsExt.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/extensions/TransportControlsExt.kt
@@ -3,6 +3,7 @@ package com.scribd.armadillo.extensions
 import android.os.Bundle
 import android.support.v4.media.session.MediaControllerCompat
 import com.scribd.armadillo.Constants
+import com.scribd.armadillo.models.AudioPlayable
 import com.scribd.armadillo.models.Chapter
 
 internal fun MediaControllerCompat.TransportControls.sendCustomAction(customAction: CustomAction) {
@@ -32,6 +33,10 @@ internal sealed class CustomAction {
                     val chapters = bundle.getParcelableArrayList<Chapter>(Constants.Actions.Extras.METADATA_CHAPTERS)!!
                     UpdatePlaybackMetadata(title, chapters)
                 }
+                Constants.Actions.UPDATE_MEDIA_REQUEST -> {
+                    val mediaRequest = bundle?.getSerializable(Constants.Actions.Extras.MEDIA_REQUEST) as AudioPlayable.MediaRequest
+                    UpdateMediaRequest(mediaRequest)
+                }
                 else -> null
             }
         }
@@ -52,6 +57,14 @@ internal sealed class CustomAction {
         override fun toBundle(): Bundle = Bundle().apply {
             putString(Constants.Actions.Extras.METADATA_TITLE, title)
             putParcelableArrayList(Constants.Actions.Extras.METADATA_CHAPTERS, ArrayList(chapters))
+        }
+    }
+
+    data class UpdateMediaRequest(val mediaRequest: AudioPlayable.MediaRequest) : CustomAction() {
+        override val action: String = Constants.Actions.UPDATE_MEDIA_REQUEST
+
+        override fun toBundle(): Bundle = Bundle().apply{
+            putSerializable(Constants.Actions.Extras.MEDIA_REQUEST, mediaRequest)
         }
     }
 

--- a/Armadillo/src/main/java/com/scribd/armadillo/playback/MediaSessionCallback.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/playback/MediaSessionCallback.kt
@@ -117,8 +117,8 @@ internal class MediaSessionCallback(private val onMediaSessionEventListener: OnM
         when (playbackInfo?.playbackState) {
             PlaybackState.PLAYING -> onPause()
             PlaybackState.PAUSED -> onPlay()
-            PlaybackState.NONE -> { /* do nothing */
-            }
+            PlaybackState.NONE -> Unit
+            null -> Unit
         }
     }
 
@@ -203,6 +203,10 @@ internal class MediaSessionCallback(private val onMediaSessionEventListener: OnM
             is CustomAction.UpdatePlaybackMetadata -> {
                 playbackEngine?.updateMetadata(customAction.title, customAction.chapters)
             }
+            is CustomAction.UpdateMediaRequest -> {
+                playbackEngine?.updateMediaRequest(customAction.mediaRequest)
+            }
+            null -> Log.e(TAG, "Custom action is null from $action with $extras")
         }
     }
 

--- a/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/MediaSourceGenerator.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/MediaSourceGenerator.kt
@@ -2,11 +2,12 @@ package com.scribd.armadillo.playback.mediasource
 
 import android.content.Context
 import com.google.android.exoplayer2.source.MediaSource
-import com.google.android.exoplayer2.upstream.cache.Cache
 import com.scribd.armadillo.models.AudioPlayable
 
 /** Creates a MediaSource for starting playback in Exoplayer when this
  * class is initialized. */
 internal interface MediaSourceGenerator {
     fun generateMediaSource(context: Context, request: AudioPlayable.MediaRequest): MediaSource
+
+    fun updateMediaSourceHeaders(request: AudioPlayable.MediaRequest)
 }

--- a/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/MediaSourceRetriever.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/MediaSourceRetriever.kt
@@ -18,7 +18,7 @@ interface MediaSourceRetriever {
     fun updateMediaSourceHeaders(request: AudioPlayable.MediaRequest)
 }
 
-class MediaSourceRetrieverImpl : MediaSourceRetriever {
+class MediaSourceRetrieverImpl @Inject constructor(): MediaSourceRetriever {
     @Inject
     internal lateinit var hlsGenerator: HlsMediaSourceGenerator
 

--- a/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/MediaSourceRetriever.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/MediaSourceRetriever.kt
@@ -14,6 +14,8 @@ import javax.inject.Inject
 interface MediaSourceRetriever {
     fun generateMediaSource(request: AudioPlayable.MediaRequest,
                             context: Context): MediaSource
+
+    fun updateMediaSourceHeaders(request: AudioPlayable.MediaRequest)
 }
 
 class MediaSourceRetrieverImpl : MediaSourceRetriever {
@@ -31,6 +33,10 @@ class MediaSourceRetrieverImpl : MediaSourceRetriever {
                                      context: Context): MediaSource {
 
         return buildMediaGenerator(request).generateMediaSource(context, request)
+    }
+
+    override fun updateMediaSourceHeaders(request: AudioPlayable.MediaRequest) {
+        buildMediaGenerator(request).updateMediaSourceHeaders(request)
     }
 
     private fun buildMediaGenerator(request: AudioPlayable.MediaRequest): MediaSourceGenerator = buildMediaGenerator(request, null)

--- a/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/ProgressiveMediaSourceGenerator.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/ProgressiveMediaSourceGenerator.kt
@@ -5,7 +5,7 @@ import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.source.MediaSource
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
 import com.google.android.exoplayer2.upstream.DataSource
-import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory
+import com.google.android.exoplayer2.upstream.DefaultDataSource
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSource
 import com.scribd.armadillo.Constants
 import com.scribd.armadillo.download.CacheManager
@@ -18,13 +18,15 @@ internal class ProgressiveMediaSourceGenerator @Inject constructor(
     override fun generateMediaSource(context: Context, request: AudioPlayable.MediaRequest): MediaSource =
         ProgressiveMediaSource.Factory(buildDataSourceFactory(context)).createMediaSource(MediaItem.fromUri(request.url))
 
+    override fun updateMediaSourceHeaders(request: AudioPlayable.MediaRequest) = Unit // Doesn't use headers
+
     private fun buildDataSourceFactory(context: Context): DataSource.Factory {
         val httpDataSourceFactory = DefaultHttpDataSource.Factory()
             .setUserAgent(Constants.getUserAgent(context))
             .setConnectTimeoutMs(DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS)
             .setReadTimeoutMs(DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS)
             .setAllowCrossProtocolRedirects(true)
-        val upstreamFactory = DefaultDataSourceFactory(context, httpDataSourceFactory)
+        val upstreamFactory = DefaultDataSource.Factory(context, httpDataSourceFactory)
         return cacheManager.playbackDataSourceFactory(context, upstreamFactory)
     }
 }

--- a/Armadillo/src/test/java/com/scribd/armadillo/ReducerTest.kt
+++ b/Armadillo/src/test/java/com/scribd/armadillo/ReducerTest.kt
@@ -3,6 +3,7 @@ package com.scribd.armadillo
 import com.scribd.armadillo.actions.Action
 import com.scribd.armadillo.actions.ContentEndedAction
 import com.scribd.armadillo.actions.FastForwardAction
+import com.scribd.armadillo.actions.MediaRequestUpdateAction
 import com.scribd.armadillo.actions.MetadataUpdateAction
 import com.scribd.armadillo.actions.NewAudioPlayableAction
 import com.scribd.armadillo.actions.PlaybackSpeedAction
@@ -13,15 +14,21 @@ import com.scribd.armadillo.actions.SkipDistanceAction
 import com.scribd.armadillo.actions.SkipNextAction
 import com.scribd.armadillo.actions.SkipPrevAction
 import com.scribd.armadillo.actions.UpdateDownloadAction
+import com.scribd.armadillo.error.ActionBeforeSetup
 import com.scribd.armadillo.error.IncorrectChapterMetadataException
+import com.scribd.armadillo.error.InvalidRequest
+import com.scribd.armadillo.models.ArmadilloState
+import com.scribd.armadillo.models.AudioPlayable
 import com.scribd.armadillo.models.Chapter
 import com.scribd.armadillo.models.DownloadState
+import com.scribd.armadillo.models.InternalState
 import com.scribd.armadillo.models.PlaybackProgress
 import com.scribd.armadillo.models.PlaybackState
 import com.scribd.armadillo.time.milliseconds
 import com.scribd.armadillo.time.minutes
 import com.scribd.armadillo.time.seconds
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -67,9 +74,9 @@ class ReducerTest {
             positionInDuration = 0.milliseconds,
             totalChaptersDuration = MockModels.audiobook().duration))
         assertThat(newPlaybackInfo.playbackSpeed).isEqualTo(Constants.DEFAULT_PLAYBACK_SPEED)
-        assertThat(newPlaybackInfo.isLoading).isTrue()
-        assertThat(newPlaybackInfo.controlState.isStartingNewAudioPlayable).isTrue()
-        assertThat(newPlaybackInfo.controlState.isStopping).isFalse()
+        assertThat(newPlaybackInfo.isLoading).isTrue
+        assertThat(newPlaybackInfo.controlState.isStartingNewAudioPlayable).isTrue
+        assertThat(newPlaybackInfo.controlState.isStopping).isFalse
     }
 
     @Test
@@ -173,13 +180,13 @@ class ReducerTest {
         val appState = Reducer.reduce(MockModels.appState(), MockModels.updateDownloadAction())
         val url = appState.playbackInfo!!.audioPlayable.request.url
         val downloadInfoBefore = appState.downloadInfoForUrl(url)
-        assertThat(downloadInfoBefore?.isDownloaded()).isFalse()
+        assertThat(downloadInfoBefore?.isDownloaded()).isFalse
 
         val newDownloadInfo = MockModels.downloadInfo().copy(downloadState = DownloadState.COMPLETED)
 
         val newAppState = Reducer.reduce(appState, UpdateDownloadAction(newDownloadInfo))
         val downloadInfoAfter = newAppState.downloadInfoForUrl(url)
-        assertThat(downloadInfoAfter!!.isDownloaded()).isTrue()
+        assertThat(downloadInfoAfter!!.isDownloaded()).isTrue
     }
 
     @Test
@@ -187,11 +194,11 @@ class ReducerTest {
         Reducer.reduce(MockModels.appState(), SkipPrevAction(100.milliseconds))
         val secondSeek = Reducer.reduce(MockModels.appState(), SkipNextAction(4000.milliseconds))
 
-        assertThat(secondSeek.playbackInfo?.controlState?.isFastForwarding ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isRewinding ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isPrevChapter ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isNextChapter).isTrue()
-        assertThat(secondSeek.playbackInfo?.controlState?.isSeeking).isTrue()
+        assertThat(secondSeek.playbackInfo?.controlState?.isFastForwarding ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isRewinding ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isPrevChapter ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isNextChapter).isTrue
+        assertThat(secondSeek.playbackInfo?.controlState?.isSeeking).isTrue
     }
 
     @Test
@@ -199,11 +206,11 @@ class ReducerTest {
         Reducer.reduce(MockModels.appState(), SkipNextAction(100.milliseconds))
         val secondSeek = Reducer.reduce(MockModels.appState(), SkipPrevAction(4000.milliseconds))
 
-        assertThat(secondSeek.playbackInfo?.controlState?.isFastForwarding ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isRewinding ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isNextChapter ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isPrevChapter).isTrue()
-        assertThat(secondSeek.playbackInfo?.controlState?.isSeeking).isTrue()
+        assertThat(secondSeek.playbackInfo?.controlState?.isFastForwarding ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isRewinding ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isNextChapter ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isPrevChapter).isTrue
+        assertThat(secondSeek.playbackInfo?.controlState?.isSeeking).isTrue
     }
 
     @Test
@@ -211,11 +218,11 @@ class ReducerTest {
         Reducer.reduce(MockModels.appState(), RewindAction(100.milliseconds))
         val secondSeek = Reducer.reduce(MockModels.appState(), FastForwardAction(4000.milliseconds))
 
-        assertThat(secondSeek.playbackInfo?.controlState?.isPrevChapter ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isRewinding ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isNextChapter ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isFastForwarding).isTrue()
-        assertThat(secondSeek.playbackInfo?.controlState?.isSeeking).isTrue()
+        assertThat(secondSeek.playbackInfo?.controlState?.isPrevChapter ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isRewinding ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isNextChapter ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isFastForwarding).isTrue
+        assertThat(secondSeek.playbackInfo?.controlState?.isSeeking).isTrue
     }
 
     @Test
@@ -223,11 +230,11 @@ class ReducerTest {
         Reducer.reduce(MockModels.appState(), FastForwardAction(100.milliseconds))
         val secondSeek = Reducer.reduce(MockModels.appState(), RewindAction(4000.milliseconds))
 
-        assertThat(secondSeek.playbackInfo?.controlState?.isPrevChapter ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isFastForwarding ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isNextChapter ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isRewinding).isTrue()
-        assertThat(secondSeek.playbackInfo?.controlState?.isSeeking).isTrue()
+        assertThat(secondSeek.playbackInfo?.controlState?.isPrevChapter ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isFastForwarding ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isNextChapter ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isRewinding).isTrue
+        assertThat(secondSeek.playbackInfo?.controlState?.isSeeking).isTrue
     }
 
     @Test
@@ -235,11 +242,11 @@ class ReducerTest {
         Reducer.reduce(MockModels.appState(), FastForwardAction(100.milliseconds))
         val secondSeek = Reducer.reduce(MockModels.appState(), SeekAction(false, null))
 
-        assertThat(secondSeek.playbackInfo?.controlState?.isFastForwarding ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isRewinding ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isPrevChapter ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isNextChapter ?: true).isFalse()
-        assertThat(secondSeek.playbackInfo?.controlState?.isSeeking).isFalse()
+        assertThat(secondSeek.playbackInfo?.controlState?.isFastForwarding ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isRewinding ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isPrevChapter ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isNextChapter ?: true).isFalse
+        assertThat(secondSeek.playbackInfo?.controlState?.isSeeking).isFalse
     }
 
     @Test
@@ -247,8 +254,8 @@ class ReducerTest {
         Reducer.reduce(MockModels.appState(), FastForwardAction(100000.milliseconds))
         val state = Reducer.reduce(MockModels.appState(), PlayerStateAction(PlaybackState.NONE))
 
-        assertThat(state.playbackInfo?.controlState?.isStopping).isTrue()
-        assertThat(state.playbackInfo?.controlState?.isFastForwarding ?: true).isFalse()
+        assertThat(state.playbackInfo?.controlState?.isStopping).isTrue
+        assertThat(state.playbackInfo?.controlState?.isFastForwarding ?: true).isFalse
     }
 
     @Test
@@ -315,7 +322,46 @@ class ReducerTest {
     fun reduce_contentEndedAction_updatesControlState() {
         val appState = Reducer.reduce(MockModels.appState(), ContentEndedAction)
 
-        assertThat(appState.playbackInfo!!.controlState.hasContentEnded).isTrue()
+        assertThat(appState.playbackInfo!!.controlState.hasContentEnded).isTrue
+    }
+
+    @Test
+    fun reduce_mediaRequestUpdateActionNotReady_error() {
+        val oldState = ArmadilloState(null, emptyList(), InternalState(false), null)
+        val action = MediaRequestUpdateAction(AudioPlayable.MediaRequest.createHttpUri(
+            "https://www.github.com/scribd/armadillo"
+        ))
+
+        assertThrows(ActionBeforeSetup::class.java) {
+            Reducer.reduce(oldState, action)
+        }
+    }
+
+    @Test
+    fun reduce_mediaRequestUpdateActionDifferentUrl_error() {
+        val oldState = MockModels.appState()
+        val action = MediaRequestUpdateAction(AudioPlayable.MediaRequest.createHttpUri(
+            "https://www.github.com/scribd/armadillo"
+        ))
+
+        assertThrows("MediaRequestUpdate cannot be used to change playback URL", InvalidRequest::class.java) {
+            Reducer.reduce(oldState, action)
+        }
+    }
+    @Test
+    fun reduce_mediaRequestUpdateAction_updatesRequest() {
+        val oldState = MockModels.appState()
+        val newRequest = AudioPlayable.MediaRequest.createHttpUri(
+            oldState.playbackInfo!!.audioPlayable.request.url,
+            mapOf(
+                "header1" to "value1",
+                "header2" to "value2"
+            )
+        )
+        val action = MediaRequestUpdateAction(newRequest)
+
+        val newState = Reducer.reduce(oldState, action)
+        assertThat(newState.playbackInfo!!.audioPlayable.request).isEqualTo(newRequest)
     }
 
     private fun resetMaxDurationDiscrepancy() {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Project Armadillo Release Notes
 
+## 1.0.9
+- Add support for updating playback headers during playback.
+
 ## 1.0.8
 - Download removal is now handled by DownloadManager rather than DownloadService
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 PACKAGE_NAME=com.scribd.armadillo
-LIBRARY_VERSION=1.0.8
+LIBRARY_VERSION=1.0.9
 EXOPLAYER_VERSION=2.17.1
 RXJAVA_VERSION=2.2.4
 RXANDROID_VERSION=2.0.1


### PR DESCRIPTION
Allows a client to pass in a new `MediaRequest` that contains new headers, and this will update the data source factory as appropriate.

For HLS, this means passing the new headers
For Progressive streams, no changes are made, as they do not support additional headers.

Resolves #19 