### PR TITLE
Seek on notification player takes the users many chapters back

### DIFF
--- a/Armadillo/src/main/java/com/scribd/armadillo/ArmadilloPlayerChoreographer.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/ArmadilloPlayerChoreographer.kt
@@ -326,7 +326,11 @@ internal class ArmadilloPlayerChoreographer : ArmadilloPlayer {
 
     override fun skipBackward() = doIfPlaybackReady { controls, _ -> controls.skipToPrevious() }
 
-    override fun seekTo(position: Milliseconds) = doIfPlaybackReady { controls, _ -> controls.seekTo(position.longValue) }
+    override fun seekTo(position: Milliseconds) = doIfPlaybackReady { controls, _ ->
+        // Add a shift constant to all seeks originating from the client application
+        // as opposed to system originated, such as from notification
+        controls.seekTo(position.longValue + Constants.AUDIO_POSITION_SHIFT_IN_MS)
+    }
 
     override fun seekWithinChapter(percent: Int) {
         val position = stateProvider.currentState.positionFromChapterPercent(percent)

--- a/Armadillo/src/main/java/com/scribd/armadillo/Constants.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/Constants.kt
@@ -14,6 +14,9 @@ object Constants {
 
     internal const val MAX_PARALLEL_DOWNLOADS = 6
 
+    // an arbitrarily long constant to add to seek positions from app UI
+    internal const val AUDIO_POSITION_SHIFT_IN_MS = 5000000000L
+
     /**
      * A seek to previousChapter command beyond this will restart the current media source instead of skipping to the previousChapter media source
      */


### PR DESCRIPTION
### Issue

When a user seeks from the app player UI all works fine, however, if the same is done from outside app, such as Notification player, Android Auto, etc. the playback jumps to a position in one of the earlier chapters.

### Solution

After researching different options, found that there is no way to communicate to the player that the seek is from the notification player. This information is needed because, the seek from the app UI is with reference to beginning of the audio content (absolute) where as the media session associated with foreground notification player is relative to the *current chapter*. This fix *injects* this information by adding a constant shift value to the seek position originating from the app and the media session seekTo() callback uses this to distinguish between app originated and notification player originated seek.

The arbitrary shift used is long enough to cover any play duration, unless there is a audio that plays for two months uninterrupted!

### Testing

Tested
- Seeks from app player UI, table of contents, bookmarks
- Seeks from notification player controls
- Android auto