### PR TITLE
[APT-9571] Build snapshot version on push to non-main branch

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Build ${{ matrix.project }} Release
         run: ./gradlew ${{ matrix.gradle-arguments }}
 
-      # Push the Library to Github packages
+      # On release/main, push build to Github packages
       - name: Publish Release
         if: matrix.project == 'Library' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         env:
@@ -104,6 +104,15 @@ jobs:
           GITHUB_PASSWORD: ${{ github.token }}
         run: |
           ./gradlew publishReleaseAarPublicationToGitHubPackagesRepository
+
+      # On other branches, push snapshot to Github packages
+      - name: Publish Snapshot
+        if: matrix.project == 'Library' && !(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+        env:
+          GITHUB_USERNAME: ${{ github.actor }}
+          GITHUB_PASSWORD: ${{ github.token }}
+        run: |
+          ./gradlew publishReleaseSnapshotAarPublicationToGitHubPackagesRepository
 
       # Upload the AAR file as a build artifact (accessible from the Summary page of the run)
       - name: Upload AAR file

--- a/Armadillo/build.gradle
+++ b/Armadillo/build.gradle
@@ -84,10 +84,23 @@ publishing {
 
     publications {
         android.libraryVariants.all { variant ->
-            "${variant.name.capitalize()}Aar"(MavenPublication) {
+            "${variant.name.capitalize()}Aar" (MavenPublication) {
                 from(components[variant.name])
                 groupId project.PACKAGE_NAME
                 version project.LIBRARY_VERSION
+                artifactId project.getName().toLowerCase()
+                // Add sources to artifact
+                artifact androidSourcesJar
+                // Add javadocs
+                artifact androidJavadocsJar
+            }
+        }
+
+        android.libraryVariants.all { variant ->
+            "${variant.name.capitalize()}SnapshotAar" (MavenPublication) {
+                from(components[variant.name])
+                groupId project.PACKAGE_NAME
+                version "${project.LIBRARY_VERSION}-SNAPSHOT"
                 artifactId project.getName().toLowerCase()
                 // Add sources to artifact
                 artifact androidSourcesJar


### PR DESCRIPTION
Builds a snapshot version on pushes to non-main branches. Snapshot has the version name `x.y.z-SNAPSHOT`

Tested by running the command locally. Only github is allowed to deploy, so it failed the push step, but everything up to there succeeded, and the version looked correct.