### PR TITLE
[APT-9568] Add model support for DRM info for streaming playback

### DIFF
--- a/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/DashMediaSourceGenerator.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/DashMediaSourceGenerator.kt
@@ -2,6 +2,7 @@ package com.scribd.armadillo.playback.mediasource
 
 import android.content.Context
 import com.google.android.exoplayer2.MediaItem
+import com.google.android.exoplayer2.MediaItem.DrmConfiguration
 import com.google.android.exoplayer2.offline.Download
 import com.google.android.exoplayer2.offline.DownloadHelper
 import com.google.android.exoplayer2.source.MediaSource
@@ -24,12 +25,20 @@ internal class DashMediaSourceGenerator @Inject constructor(
             }
         }
 
-        val mediaItem = MediaItem.Builder()
+        val mediaItemBuilder = MediaItem.Builder()
             .setUri(request.url)
-            .build()
+
+        if (request.drmInfo != null) {
+            mediaItemBuilder.setDrmConfiguration(
+                DrmConfiguration.Builder(request.drmInfo.drmType.toExoplayerConstant())
+                    .setLicenseUri(request.drmInfo.licenseServer)
+                    .setLicenseRequestHeaders(request.drmInfo.drmHeaders)
+                    .build()
+            )
+        }
 
         return DashMediaSource.Factory(dataSourceFactory)
-            .createMediaSource(mediaItem)
+            .createMediaSource(mediaItemBuilder.build())
     }
 
     override fun updateMediaSourceHeaders(request: AudioPlayable.MediaRequest) = mediaSourceHelper.updateMediaSourceHeaders(request)

--- a/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/HlsMediaSourceGenerator.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/HlsMediaSourceGenerator.kt
@@ -1,6 +1,7 @@
 package com.scribd.armadillo.playback.mediasource
 
 import android.content.Context
+import android.util.Log
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.offline.Download
 import com.google.android.exoplayer2.offline.DownloadHelper
@@ -28,6 +29,11 @@ internal class HlsMediaSourceGenerator @Inject constructor(
                 return DownloadHelper.createMediaSource(it.request, dataSourceFactory)
             }
         }
+
+        if (request.drmInfo != null) {
+            Log.e(MediaSourceGenerator.TAG, "HLS does not currently support DRM")
+        }
+
         return HlsMediaSource.Factory(dataSourceFactory)
             .createMediaSource(MediaItem.fromUri(request.url))
     }

--- a/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/MediaSourceGenerator.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/MediaSourceGenerator.kt
@@ -7,6 +7,10 @@ import com.scribd.armadillo.models.AudioPlayable
 /** Creates a MediaSource for starting playback in Exoplayer when this
  * class is initialized. */
 internal interface MediaSourceGenerator {
+    companion object {
+        const val TAG = "MediaSourceGenerator"
+    }
+
     fun generateMediaSource(context: Context, request: AudioPlayable.MediaRequest): MediaSource
 
     fun updateMediaSourceHeaders(request: AudioPlayable.MediaRequest)

--- a/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/ProgressiveMediaSourceGenerator.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/playback/mediasource/ProgressiveMediaSourceGenerator.kt
@@ -1,6 +1,7 @@
 package com.scribd.armadillo.playback.mediasource
 
 import android.content.Context
+import android.util.Log
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.source.MediaSource
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
@@ -16,7 +17,11 @@ internal class ProgressiveMediaSourceGenerator @Inject constructor(
     private val cacheManager: CacheManager) : MediaSourceGenerator {
 
     override fun generateMediaSource(context: Context, request: AudioPlayable.MediaRequest): MediaSource =
-        ProgressiveMediaSource.Factory(buildDataSourceFactory(context)).createMediaSource(MediaItem.fromUri(request.url))
+        ProgressiveMediaSource.Factory(buildDataSourceFactory(context)).createMediaSource(MediaItem.fromUri(request.url)).also {
+            if (request.drmInfo != null) {
+                Log.e(MediaSourceGenerator.TAG, "Progressive media does not currently support DRM")
+            }
+        }
 
     override fun updateMediaSourceHeaders(request: AudioPlayable.MediaRequest) = Unit // Doesn't use headers
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Project Armadillo Release Notes
 
+## 1.3.0
+- Adds support for DRM when playing MPEG-DASH audio
+
 ## 1.2.0
 - Adds support for MPEG-DASH audio
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 PACKAGE_NAME=com.scribd.armadillo
-LIBRARY_VERSION=1.2.0
+LIBRARY_VERSION=1.3.0
 EXOPLAYER_VERSION=2.17.1
 RXJAVA_VERSION=2.2.4
 RXANDROID_VERSION=2.0.1


### PR DESCRIPTION
This takes in a license server and DRM headers to start playback of DRM-protected content

This does not provide support for offline playback (coming soon)