### PR TITLE
[APT-10128] Update Reducer logic to copy seek position to playbackinfo

### DIFF
--- a/Armadillo/src/main/java/com/scribd/armadillo/Reducer.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/Reducer.kt
@@ -189,15 +189,10 @@ internal object Reducer {
             }
             is FastForwardAction -> {
                 val playbackInfo = oldState.playbackInfo ?: throw ActionBeforeSetup(action)
-                val progress = if (action.seekPositionTarget != null) {
-                    playbackInfo.progress.copy(
-                        positionInDuration = action.seekPositionTarget,
-                        currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget))
-                } else {
-                    playbackInfo.progress
-                }
                 oldState.copy(playbackInfo = playbackInfo.copy(
-                        progress = progress,
+                        progress = playbackInfo.progress.copy(
+                            positionInDuration = action.seekPositionTarget,
+                            currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget)),
                         controlState = MediaControlState(
                                 isSeeking = true,
                                 isFastForwarding = true,
@@ -206,15 +201,10 @@ internal object Reducer {
             }
             is RewindAction -> {
                 val playbackInfo = oldState.playbackInfo ?: throw ActionBeforeSetup(action)
-                val progress = if (action.seekPositionTarget != null) {
-                    playbackInfo.progress.copy(
-                        positionInDuration = action.seekPositionTarget,
-                        currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget))
-                } else {
-                    playbackInfo.progress
-                }
                 oldState.copy(playbackInfo = playbackInfo.copy(
-                        progress = progress,
+                        progress = playbackInfo.progress.copy(
+                            positionInDuration = action.seekPositionTarget,
+                            currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget)),
                         controlState = MediaControlState(
                                 isSeeking = true,
                                 isRewinding = true,
@@ -223,15 +213,10 @@ internal object Reducer {
             }
             is SkipNextAction -> {
                 val playbackInfo = oldState.playbackInfo ?: throw ActionBeforeSetup(action)
-                val progress = if (action.seekPositionTarget != null) {
-                    playbackInfo.progress.copy(
-                        positionInDuration = action.seekPositionTarget,
-                        currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget))
-                } else {
-                    playbackInfo.progress
-                }
                 oldState.copy(playbackInfo = playbackInfo.copy(
-                        progress = progress,
+                        progress = playbackInfo.progress.copy(
+                            positionInDuration = action.seekPositionTarget,
+                            currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget)),
                         controlState = MediaControlState(
                                 isSeeking = true,
                                 isNextChapter = true,
@@ -240,15 +225,10 @@ internal object Reducer {
             }
             is SkipPrevAction -> {
                 val playbackInfo = oldState.playbackInfo ?: throw ActionBeforeSetup(action)
-                val progress = if (action.seekPositionTarget != null) {
-                    playbackInfo.progress.copy(
-                        positionInDuration = action.seekPositionTarget,
-                        currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget))
-                } else {
-                    playbackInfo.progress
-                }
                 oldState.copy(playbackInfo = playbackInfo.copy(
-                        progress = progress,
+                        progress = playbackInfo.progress.copy(
+                            positionInDuration = action.seekPositionTarget,
+                            currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget)),
                         controlState = MediaControlState(
                                 isSeeking = true,
                                 isPrevChapter = true,

--- a/Armadillo/src/main/java/com/scribd/armadillo/Reducer.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/Reducer.kt
@@ -175,14 +175,29 @@ internal object Reducer {
                             isSeeking = action.isSeeking,
                             seekTarget = action.seekPositionTarget)
                 } else MediaControlState()
-
+                val progress = if (action.seekPositionTarget != null) {
+                    playbackInfo.progress.copy(
+                        positionInDuration = action.seekPositionTarget,
+                        currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget))
+                } else {
+                    playbackInfo.progress
+                }
                 oldState.copy(playbackInfo = playbackInfo.copy(
+                        progress = progress,
                         controlState = controlState))
                         .apply { debugState = newDebug }
             }
             is FastForwardAction -> {
                 val playbackInfo = oldState.playbackInfo ?: throw ActionBeforeSetup(action)
+                val progress = if (action.seekPositionTarget != null) {
+                    playbackInfo.progress.copy(
+                        positionInDuration = action.seekPositionTarget,
+                        currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget))
+                } else {
+                    playbackInfo.progress
+                }
                 oldState.copy(playbackInfo = playbackInfo.copy(
+                        progress = progress,
                         controlState = MediaControlState(
                                 isSeeking = true,
                                 isFastForwarding = true,
@@ -191,7 +206,15 @@ internal object Reducer {
             }
             is RewindAction -> {
                 val playbackInfo = oldState.playbackInfo ?: throw ActionBeforeSetup(action)
+                val progress = if (action.seekPositionTarget != null) {
+                    playbackInfo.progress.copy(
+                        positionInDuration = action.seekPositionTarget,
+                        currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget))
+                } else {
+                    playbackInfo.progress
+                }
                 oldState.copy(playbackInfo = playbackInfo.copy(
+                        progress = progress,
                         controlState = MediaControlState(
                                 isSeeking = true,
                                 isRewinding = true,
@@ -200,7 +223,15 @@ internal object Reducer {
             }
             is SkipNextAction -> {
                 val playbackInfo = oldState.playbackInfo ?: throw ActionBeforeSetup(action)
+                val progress = if (action.seekPositionTarget != null) {
+                    playbackInfo.progress.copy(
+                        positionInDuration = action.seekPositionTarget,
+                        currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget))
+                } else {
+                    playbackInfo.progress
+                }
                 oldState.copy(playbackInfo = playbackInfo.copy(
+                        progress = progress,
                         controlState = MediaControlState(
                                 isSeeking = true,
                                 isNextChapter = true,
@@ -209,7 +240,15 @@ internal object Reducer {
             }
             is SkipPrevAction -> {
                 val playbackInfo = oldState.playbackInfo ?: throw ActionBeforeSetup(action)
+                val progress = if (action.seekPositionTarget != null) {
+                    playbackInfo.progress.copy(
+                        positionInDuration = action.seekPositionTarget,
+                        currentChapterIndex = playbackInfo.audioPlayable.getChapterIndexAtOffset(action.seekPositionTarget))
+                } else {
+                    playbackInfo.progress
+                }
                 oldState.copy(playbackInfo = playbackInfo.copy(
+                        progress = progress,
                         controlState = MediaControlState(
                                 isSeeking = true,
                                 isPrevChapter = true,

--- a/Armadillo/src/main/java/com/scribd/armadillo/actions/Action.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/actions/Action.kt
@@ -61,19 +61,19 @@ internal data class SeekAction(val isSeeking: Boolean, val seekPositionTarget: M
     override val name = "Seeking: $isSeeking"
 }
 
-internal data class FastForwardAction(val seekPositionTarget: Milliseconds?) : Action {
+internal data class FastForwardAction(val seekPositionTarget: Milliseconds) : Action {
     override val name = "FastForwardAction: $seekPositionTarget"
 }
 
-internal data class RewindAction(val seekPositionTarget: Milliseconds?) : Action {
+internal data class RewindAction(val seekPositionTarget: Milliseconds) : Action {
     override val name = "RewindAction: $seekPositionTarget"
 }
 
-internal data class SkipNextAction(val seekPositionTarget: Milliseconds?) : Action {
+internal data class SkipNextAction(val seekPositionTarget: Milliseconds) : Action {
     override val name = "SkipNextAction: $seekPositionTarget"
 }
 
-internal data class SkipPrevAction(val seekPositionTarget: Milliseconds?) : Action {
+internal data class SkipPrevAction(val seekPositionTarget: Milliseconds) : Action {
     override val name = "SkipNextAction: $seekPositionTarget"
 }
 

--- a/Armadillo/src/test/java/com/scribd/armadillo/ReducerTest.kt
+++ b/Armadillo/src/test/java/com/scribd/armadillo/ReducerTest.kt
@@ -62,6 +62,70 @@ class ReducerTest {
     }
 
     @Test
+    fun reduce_seek_updatesPlaybackAndControlState() {
+        val targetDistance = 10.milliseconds
+        val newState = Reducer.reduce(MockModels.appState(), SeekAction(true, targetDistance))
+        assertThat(newState.playbackInfo!!.progress.positionInDuration).isEqualTo(targetDistance)
+        assertThat(newState.playbackInfo!!.progress.currentChapterIndex).isEqualTo(0)
+
+        val controlState = newState.playbackInfo!!.controlState
+        assertThat(controlState.isSeeking).isTrue
+        assertThat(controlState.seekTarget).isEqualTo(targetDistance)
+    }
+
+    @Test
+    fun reduce_fastForward_updatesPlaybackAndControlState() {
+        val targetDistance = 10.milliseconds
+        val newState = Reducer.reduce(MockModels.appState(), FastForwardAction(targetDistance))
+        assertThat(newState.playbackInfo!!.progress.positionInDuration).isEqualTo(targetDistance)
+        assertThat(newState.playbackInfo!!.progress.currentChapterIndex).isEqualTo(0)
+
+        val controlState = newState.playbackInfo!!.controlState
+        assertThat(controlState.isSeeking).isTrue
+        assertThat(controlState.seekTarget).isEqualTo(targetDistance)
+        assertThat(controlState.isFastForwarding).isTrue
+    }
+
+    @Test
+    fun reduce_rewind_updatesPlaybackAndControlState() {
+        val targetDistance = 10.milliseconds
+        val newState = Reducer.reduce(MockModels.appState(), RewindAction(targetDistance))
+        assertThat(newState.playbackInfo!!.progress.positionInDuration).isEqualTo(targetDistance)
+        assertThat(newState.playbackInfo!!.progress.currentChapterIndex).isEqualTo(0)
+
+        val controlState = newState.playbackInfo!!.controlState
+        assertThat(controlState.isSeeking).isTrue
+        assertThat(controlState.seekTarget).isEqualTo(targetDistance)
+        assertThat(controlState.isRewinding).isTrue
+    }
+
+    @Test
+    fun reduce_skipNext_updatesPlaybackAndControlState() {
+        val targetDistance = 10.milliseconds
+        val newState = Reducer.reduce(MockModels.appState(), SkipNextAction(targetDistance))
+        assertThat(newState.playbackInfo!!.progress.positionInDuration).isEqualTo(targetDistance)
+        assertThat(newState.playbackInfo!!.progress.currentChapterIndex).isEqualTo(0)
+
+        val controlState = newState.playbackInfo!!.controlState
+        assertThat(controlState.isSeeking).isTrue
+        assertThat(controlState.seekTarget).isEqualTo(targetDistance)
+        assertThat(controlState.isNextChapter).isTrue
+    }
+
+    @Test
+    fun reduce_skipPrev_updatesPlaybackAndControlState() {
+        val targetDistance = 10.milliseconds
+        val newState = Reducer.reduce(MockModels.appState(), SkipPrevAction(targetDistance))
+        assertThat(newState.playbackInfo!!.progress.positionInDuration).isEqualTo(targetDistance)
+        assertThat(newState.playbackInfo!!.progress.currentChapterIndex).isEqualTo(0)
+
+        val controlState = newState.playbackInfo!!.controlState
+        assertThat(controlState.isSeeking).isTrue
+        assertThat(controlState.seekTarget).isEqualTo(targetDistance)
+        assertThat(controlState.isPrevChapter).isTrue
+    }
+
+    @Test
     fun reduce_NewAudiobookAction() {
         val newState = Reducer.reduce(MockModels.appState(),
             NewAudioPlayableAction(MockModels.audiobook(),

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Project Armadillo Release Notes
 
+## 1.3.2
+- Added a fix for updating the playback info progress in the reducer for seek related controls
+
 ## 1.3.1
 - Adds support for offline DRM for downloaded MPEG-DASH audio
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 PACKAGE_NAME=com.scribd.armadillo
-LIBRARY_VERSION=1.3.1
+LIBRARY_VERSION=1.3.2
 EXOPLAYER_VERSION=2.17.1
 RXJAVA_VERSION=2.2.4
 RXANDROID_VERSION=2.0.1


### PR DESCRIPTION
## Jira ticket

https://scribdjira.atlassian.net/browse/APT-10128

## Description

Bug:
When the audio player is paused and the user performs some combination of audio controls (seeking, chapter jumping, skip fwd back, etc), then force closes the app. The progress is updated, but is not the latest and is not correct. While in the paused state, the user would likely be losing their latest listening progress. This differs from the user closing the audio player in-app because in that scenario, the progress is correctly saved.

Explanation:
After much digging, when the audio player performs some audio control, say Seek, it would trigger the armadillo player to dispatch a Seek Action and the Reducer would update the armadillo state to be emitted to the listeners for said action.

Currently in the Scribd app, whenever the action listener would receive the armadillo state, it would look into `PlaybackInfo.progress.positionInDuration`. If you look at the Reducer in the armadillo player library, you can immediately see that the playbackinfo is not updated, only the controlstate, which is why when we are saving the progress, the progress is not updated to what it should be after performing the media control action. It would make sense to update the playbackinfo following these skips, seeks, etc. since prior to the emission, the exoplayer's position is already updated to where we are skipping.

Fix:
Update reducer to update the playbackinfo progress in terms of position and chapter index (we may be able to jump to the next or previous chapter). Now when paused and jumping around the audio, the progress is correctly save the same way whether we close the audio player in-app or force close.

## Testing considerations

Introduced unit tests
Regression around audio controls (skip fwd, back, seek, jump to chapter, etc.) leading to progress saved while playing or paused.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes
- [x] The appropriate complexity label (Low, Medium, High) is added to this PR
- [x] Test Coverage of changes (if applicable)
- [x] Updated the `README.md` as necessary
- [x] I have confirmed and checked all of these boxes

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [#XYZ](https://github.com/scribd/REPO/pull/XYZ)
* [JIRXXX](https://scribdjira.atlassian.net/browse/JIRXXX)
* [Design Document](https://scribdjira.atlassian.net/wiki/spaces/SPACEID/pages/PAGEID)
* [Slack discussion](https://scribd.slack.com/archives/C0DSL144T/p1564610596278400)

[commit messages]: https://chris.beams.io/posts/git-commit/
