### PR TITLE
[APT-10128] Fixed the order of dispatched actions during seek related…

### DIFF
--- a/Armadillo/src/main/java/com/scribd/armadillo/playback/PlaybackEngine.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/playback/PlaybackEngine.kt
@@ -243,7 +243,7 @@ internal class ExoplayerPlaybackEngine(private var audioPlayable: AudioPlayable)
     }
 
     private fun seekToExo(position: Milliseconds) {
-        exoPlayer.seekTo(exoPlayer.currentMediaItemIndex, position.longValue)
         stateModifier.dispatch(PlaybackProgressAction(position, exoPlayer.playerDuration()))
+        exoPlayer.seekTo(exoPlayer.currentMediaItemIndex, position.longValue)
     }
 }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,8 @@
 # Project Armadillo Release Notes
 
+## 1.3.2
+- Added a fix for order of dispatched actions during seek related events
+
 ## 1.3.1
 - Adds support for offline DRM for downloaded MPEG-DASH audio
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 PACKAGE_NAME=com.scribd.armadillo
-LIBRARY_VERSION=1.3.1
+LIBRARY_VERSION=1.3.2
 EXOPLAYER_VERSION=2.17.1
 RXJAVA_VERSION=2.2.4
 RXANDROID_VERSION=2.0.1


### PR DESCRIPTION
… events

Currently the order of the actions dispatched on a seeking action: 

1. Intial Seeking action (Skip distance, Prev chapter, seek position, etc.) 
2. Finish Seeking action because we immediately call exoplayer to seek to the new position and this triggers the Seek listeners with the current armadillo state without playback info being updated. 
3. Then dispatch PlaybackProgressAction with the new position that updates the armadillo state's playback info

Instead we reverse the order of the final seek action and PlaybackProgressAction so we are able to update the playback info progress before the finish seek occurs so it has the correctly updated playback info just before the listeners are triggered.

I also think that the PlaybackProgressAction order in the original code was likely misordered in the first place. 
Normally, the PlaybackProgressAction gets fired a few times a second whether paused or playing that gets the exoplayer position, and updates the playback info progress with it. Having it run at the end of the sequence of events is redundant since it'll happen anyway. I think it might be that the intention was to use PlaybackProgressAction to update the playback info progress BEFORE the last finishing seek action is dispatched so it has the right progress that matches the finished seek position.

Changing this order now correctly sends the updated seek position to the audio player app for all the discontinuous jumps we make while paused and correctly saves the progress whether closing the audio player or force closing while paused.