### PR TITLE
[APT-10650] Better DrmInfo Resilience

### DIFF
--- a/Armadillo/src/main/java/com/scribd/armadillo/playback/ExoPlaybackExceptionExt.kt
+++ b/Armadillo/src/main/java/com/scribd/armadillo/playback/ExoPlaybackExceptionExt.kt
@@ -6,12 +6,14 @@ import com.google.android.exoplayer2.ExoPlaybackException.TYPE_RENDERER
 import com.google.android.exoplayer2.ExoPlaybackException.TYPE_SOURCE
 import com.google.android.exoplayer2.ParserException
 import com.google.android.exoplayer2.audio.AudioSink
+import com.google.android.exoplayer2.drm.DrmSession.DrmSessionException
 import com.google.android.exoplayer2.drm.MediaDrmCallbackException
 import com.google.android.exoplayer2.upstream.DataSpec
 import com.google.android.exoplayer2.upstream.HttpDataSource
 import com.scribd.armadillo.error.ArmadilloException
 import com.scribd.armadillo.error.ArmadilloIOException
 import com.scribd.armadillo.error.ConnectivityException
+import com.scribd.armadillo.error.DrmPlaybackException
 import com.scribd.armadillo.error.HttpResponseCodeException
 import com.scribd.armadillo.error.ParsingException
 import com.scribd.armadillo.error.RendererConfigurationException
@@ -38,6 +40,9 @@ internal fun ExoPlaybackException.toArmadilloException(context: Context): Armadi
                     val httpCause = source.cause as? HttpDataSource.InvalidResponseCodeException
                     HttpResponseCodeException(httpCause?.responseCode
                         ?: 0, httpCause?.dataSpec?.uri.toString(), source, source.dataSpec.toAnalyticsMap(context))
+                }
+                is DrmSessionException -> {
+                    DrmPlaybackException(cause = this)
                 }
 
                 is UnknownHostException,

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,7 @@
 
 ## 1.6.8
 - Fixes an app startup crash to EncryptedSharedPreference faults. 
+- Adds resilience to playing unencrypted content if it is optionally drm enabled.
 
 ## 1.6.7
 - Adds additional data in audio player errors: HttpResponseCodeException, DownloadFailed


### PR DESCRIPTION
Indented, view without whitespace. 

Armadillo to simply took the DRMInfo passed into it for granted without checking whether the content even needed a key to play. Exoplayer can raise an exception on its own and didn't need the DrmMediaSourceHelper to throw its own exceptions separately.

This can help when the client has optional DRM content or has an oops with data persistence. 